### PR TITLE
Fix statsd

### DIFF
--- a/crankshaft/statsd.go
+++ b/crankshaft/statsd.go
@@ -8,7 +8,7 @@ import (
 )
 
 type statsdBackend struct {
-	*statsd.Client
+	*statsd.Statter
 }
 
 func GetStatsClient() *statsdBackend {
@@ -17,7 +17,7 @@ func GetStatsClient() *statsdBackend {
 
 	log.Println("Opening StatsD Backend to", backend, "prefix:", prefix)
 
-	client, err := statsd.New(backend, prefix)
+	client, err := statsd.NewClient(backend, prefix)
 	if err != nil {
 		log.Println("Error creating StatsD client")
 	}


### PR DESCRIPTION
Attempting to build the project gives an error:
```
$ go build
# github.com/xorlev/crankshaftd/crankshaft
crankshaft/statsd.go:25: cannot use client (type statsd.Statter) as type *statsd.Client in field value: need type assertion
```

From the [go-statsd-client changelog](https://github.com/cactus/go-statsd-client/blob/master/CHANGELOG.md#200-2015-03-19):

> clean up interfaces -- BREAKING CHANGE: for users who previously defined types as *Client instead of the Statter interface type.